### PR TITLE
Show amount of players left in room when reconnecting

### DIFF
--- a/Mods/Important.cs
+++ b/Mods/Important.cs
@@ -23,9 +23,20 @@ namespace iiMenu.Mods
 
         public static void Reconnect()
         {
+            int PlayerCount = PhotonNetwork.CurrentRoom.PlayerCount;
+            PlayerCount = PlayerCount - 1;
             rejRoom = PhotonNetwork.CurrentRoom.Name;
             //rejDebounce = Time.time + (float)internetTime;
             PhotonNetwork.Disconnect();
+            //Hide messages temporarily mainly to hide the anti report messages so you can see the player count.
+            for(int i = 0; i < 10; i++)
+            {
+             NotifiLib.ClearAllNotifications();
+            }
+            for(int i2 = 0; i2 < 10; i2++)
+            {
+            NotifiLib.SendNotification(PlayerCount + " players in room. Rejoining!");
+            }
         }
 
         public static void DisconnectR()


### PR DESCRIPTION
Shows amount of players left in lobby when you reconnect so you can get a better understanding if its full or not.
leave a full game

9 players left in room. Rejoining!
9 players left in room. Rejoining!
9 players left in room. Rejoining!
9 players left in room. Rejoining!
9 players left in room. Rejoining!
9 players left in room. Rejoining!

then when its taking a while to reconnect you know for sure that someone else joined when you had disconnected.