### PR TITLE
notificationDecayTime now has an effect

### DIFF
--- a/Notifications/Library.cs
+++ b/Notifications/Library.cs
@@ -238,7 +238,7 @@ namespace iiMenu.Notifications
 
         public static IEnumerator ClearLast()
         {
-            yield return new WaitForSeconds(1);
+            yield return new WaitForSeconds(notificationDecayTime/1000);
             ClearPastNotifications(1);
         }
 


### PR DESCRIPTION
Menu setting "Change Notification Time" changes notificationDecayTime but notificationDecayTime didn't change how long before notifications are destroyed.