### PR TITLE
Player Count mod

### DIFF
--- a/Mods/Buttons.cs
+++ b/Mods/Buttons.cs
@@ -612,6 +612,9 @@ namespace iiMenu.Menu
                 new ButtonInfo { buttonText = "Nearby Label", method =() => Visuals.NearbyTaggerLabel(), toolTip = "Puts text on your left hand, showing you the distance of the nearest tagger."},
                 new ButtonInfo { buttonText = "Last Label", method =() => Visuals.LastLabel(), toolTip = "Puts text on your left hand, showing you how many untagged people are left."},
                 new ButtonInfo { buttonText = "Time Label", method =() => Visuals.TimeLabel(), toolTip = "Puts text on your right hand, showing how long you've been playing for without getting tagged."},
+                
+                new ButtonInfo { buttonText = "Player Count", method =() => Visuals.PlayerCount(), toolTip = "Shows the amount of players connected to the lobby."},
+
 
                 new ButtonInfo { buttonText = "Info Watch", enableMethod =() => Visuals.WatchOn(), method =() => Visuals.WatchStep(), disableMethod =() => Visuals.WatchOff(), toolTip = "Puts a watch on your hand that tells you the time and your FPS."},
 

--- a/Mods/Visuals.cs
+++ b/Mods/Visuals.cs
@@ -394,6 +394,17 @@ namespace iiMenu.Mods
             }
         }
 
+        public static float PlayerCountRefreshDelay;
+        public static void PlayerCount()
+        {
+            if (!PhotonNetwork.InRoom) return;
+            if (Time.time > PlayerCountRefreshDelay)
+            {
+                PlayerCountRefreshDelay = Time.time + 1f;
+                NotifiLib.SendNotification(PhotonNetwork.CurrentRoom.PlayerCount.ToString() + " Players", 1000);
+            }
+        }
+
         public static void FakeUnbanSelf()
         {
             PhotonNetworkController.Instance.UpdateTriggerScreens();


### PR DESCRIPTION
I could use the hand label system but there is only so many things you can have on your hands.
Instead I used notifications to send a 1000ms notification every 1000ms and without a prefix it looks good.
Format: "[players] Players"

I'm out of ideas so I hope todays update is good.