### PR TITLE
Stat system

### DIFF
--- a/Notifications/Library.cs
+++ b/Notifications/Library.cs
@@ -19,7 +19,6 @@ namespace iiMenu.Notifications
         public static NotifiLib instance;
         public GameObject HUDObj;
         public GameObject HUDObj2;
-        public GameObject HUDObj3;
 
         private GameObject MainCamera;
 
@@ -49,10 +48,6 @@ namespace iiMenu.Notifications
             {
                 name = "NOTIFICATIONLIB_HUD_OBJ"
             };
-            HUDObj3 = new GameObject
-            {
-                name = "NOTIFICATIONLIB_HUD_OBJ"
-            };
             HUDObj.name = "NOTIFICATIONLIB_HUD_OBJ";
             HUDObj.AddComponent<Canvas>();
             HUDObj.AddComponent<CanvasScaler>().dynamicPixelsPerUnit *= highQualityText ? 2f : 1f;
@@ -63,7 +58,6 @@ namespace iiMenu.Notifications
             HUDObj.GetComponent<RectTransform>().sizeDelta = new Vector2(5f, 5f);
             HUDObj.GetComponent<RectTransform>().position = new Vector3(MainCamera.transform.position.x, MainCamera.transform.position.y, MainCamera.transform.position.z);
             HUDObj2.transform.position = new Vector3(MainCamera.transform.position.x, MainCamera.transform.position.y, MainCamera.transform.position.z - 4.6f);
-            HUDObj3.transform.position = new Vector3(MainCamera.transform.position.x, MainCamera.transform.position.y, MainCamera.transform.position.z - 4.6f);
             HUDObj.transform.parent = HUDObj2.transform;
             HUDObj.GetComponent<RectTransform>().localPosition = new Vector3(0f, 0f, 1.6f);
             Vector3 eulerAngles = HUDObj.GetComponent<RectTransform>().rotation.eulerAngles;
@@ -132,8 +126,6 @@ namespace iiMenu.Notifications
                 }
                 HUDObj2.transform.position = new Vector3(MainCamera.transform.position.x, MainCamera.transform.position.y, MainCamera.transform.position.z);
                 HUDObj2.transform.rotation = MainCamera.transform.rotation;
-                HUDObj3.transform.position = new Vector3(MainCamera.transform.position.x, MainCamera.transform.position.y, MainCamera.transform.position.z);
-                HUDObj3.transform.rotation = MainCamera.transform.rotation;
                 try
                 {
                     ModText.font = activeFont;


### PR DESCRIPTION
An easy to use stat system.
NotifiLib.osStats["fps"] = string // this changes the "fps" stat to show whatever string is.
NotifiLib.osStats.Remove("fps") // this removes a stat from showing on screen
the name for a stat isn't shown on screen, only it's value

some example ones i made (not in this commit)

`new ButtonInfo { buttonText = "stat fps", method =() => NotifiLib.osStats["fps"] = Mathf.Ceil(1f / Time.unscaledDeltaTime).ToString()+" FPS", disableMethod =() => NotifiLib.osStats.Remove("fps"), toolTip = "fps counter" },`
and
`new ButtonInfo { buttonText = "stat players", method =() => NotifiLib.osStats["players"] = PhotonNetwork.CurrentRoom.PlayerCount.ToString()+" Players", disableMethod =() => NotifiLib.osStats.Remove("players"), toolTip = "player counter" },`


edit: I updated this to remove a object I didn't use