### PR TITLE
extenders

### DIFF
--- a/Menu/Buttons.cs
+++ b/Menu/Buttons.cs
@@ -515,6 +515,8 @@ namespace iiMenu.Menu
                 new ButtonInfo { buttonText = "Vertical Long Arms", method =() => Movement.VerticalLongArms(), toolTip = "Gives you a version of long arms to help you vertically."},
                 new ButtonInfo { buttonText = "Horizontal Long Arms", method =() => Movement.HorizontalLongArms(), toolTip = "Gives you a version of long arms to help you horizontally."},
 
+                new ButtonInfo { buttonText = "Extenders <color=grey>[</color><color=green>J</color><color=grey>]</color>", method =() => Movement.Extenders(), enableMethod =() => Movement.extendingTime = 0f, disableMethod =() => Movement.DisableSteamLongArms(), toolTip = "Steam long arms, but it slowly disables when holding the right trigger."},
+
                 new ButtonInfo { buttonText = "Flick Jump <color=grey>[</color><color=green>A</color><color=grey>]</color>", method =() => Movement.FlickJump(), toolTip = "Makes your hand go down really fast when holding <color=green>A</color>."},
 
                 new ButtonInfo { buttonText = "Bunny Hop", method =() => Movement.BunnyHop(), toolTip = "Makes you automatically jump when on the ground."},

--- a/Mods/Movement.cs
+++ b/Mods/Movement.cs
@@ -3070,6 +3070,17 @@ namespace iiMenu.Mods
         public static void DisableSteamLongArms() =>
             GTPlayer.Instance.transform.localScale = Vector3.one;
 
+        public static float extendingTime;
+        public static void Extenders()
+        {
+            extendingTime += rightJoystickClick ? 0 - Time.unscaledDeltaTime : Time.unscaledDeltaTime;
+            if (extendingTime > 1) extendingTime = 1;
+            if (extendingTime < 0) extendingTime = 0;
+
+            float delayedLength = ((armlength - 1f) * extendingTime) + 1f;
+            GTPlayer.Instance.transform.localScale = new Vector3(delayedLength, delayedLength, delayedLength);
+        }
+
         public static void MultipliedLongArms()
         {
             GTPlayer.Instance.leftControllerTransform.transform.position = GorillaTagger.Instance.headCollider.transform.position - (GorillaTagger.Instance.headCollider.transform.position - GorillaTagger.Instance.leftHandTransform.position) * armlength;


### PR DESCRIPTION
steam long arms, but if you hold your right trigger down it disables over 1 second. when you release it enables over one second.

if you aren't using an extreme amount of long arms this can be used to make it look like you aren't (because it doesnt snap to turn off) using them in a check and then after you can release trigger to enable them (also without snapping on).

not what i wanted to make, it WILL come tomorrow (when i dont have time issues again hopefully).