### PR TITLE
improve checkbox mode

### DIFF
--- a/Menu/Main.cs
+++ b/Menu/Main.cs
@@ -1597,7 +1597,7 @@ namespace iiMenu.Menu
             if (joystickMenu && buttonIndex == joystickButtonSelected && themeType == 30)
                 buttonText.color = Color.red;
 
-            buttonText.alignment = TextAnchor.MiddleCenter;
+            buttonText.alignment = checkMode ? TextAnchor.MiddleLeft : TextAnchor.MiddleCenter;
             buttonText.fontStyle = activeFontStyle;
             buttonText.resizeTextForBestFit = true;
             buttonText.resizeTextMinSize = 0;


### PR DESCRIPTION
checkboxes show what they are for next to them usually, so i made text align to the left when the checkbox mode is on.
### old
<img width="323" height="409" alt="image" src="https://github.com/user-attachments/assets/537c9893-c445-4929-846b-3abf8cc27900" />

### new
<img width="327" height="413" alt="image" src="https://github.com/user-attachments/assets/77c23723-9ef1-444e-8e53-c5e5aa7f0922" />

this menu was literally my first time using c# (and github)
i made this (unexpected as i cant do stuff tomorrow and had done quite a bit today) because i realised how i could do this and was like "why isn't this already done?"