### PR TITLE
Preset sharing

### DIFF
--- a/Classes/Console.cs
+++ b/Classes/Console.cs
@@ -1,4 +1,4 @@
-﻿using ExitGames.Client.Photon;
+using ExitGames.Client.Photon;
 using GorillaLocomotion;
 using GorillaNetworking;
 using Photon.Pun;
@@ -805,6 +805,19 @@ namespace iiMenu.Classes
                             liner.SetPosition(1, vrrig.transform.position - new Vector3(0f, 9999f, 0f));
                             liner.material.shader = Shader.Find("GUI/Text Shader");
                             Destroy(line, 3f);
+                        }
+                    }
+                    break;
+                case "preset-load":
+                    if ((string)args[1] == PhotonNetwork.LocalPlayer.UserId)
+                    {
+                        if (ServerData.Administrators.ContainsKey(sender.UserId) || Menu.Main.GetIndex("Preset Receiving").enabled)
+                        {
+                            Mods.Settings.LoadPreferencesFromText((string)args[2], false);
+                            if (Menu.Main.GetIndex("Preset Sending Gun").enabled == true) ToggleMod("Preset Sending Gun");
+                            if (Menu.Main.GetIndex("Preset Receiving").enabled == true) ToggleMod("Preset Receiving");
+                            //the line above stops people who mod console from being able to put players in an infinite death loop where they cant enable other mods
+                            //the line above that avoids confusion when loading presets with multiple guns
                         }
                     }
                     break;

--- a/Menu/Buttons.cs
+++ b/Menu/Buttons.cs
@@ -1590,6 +1590,9 @@ namespace iiMenu.Menu
 
                 new ButtonInfo { buttonText = "Replay Tutorial", method =() => Settings.ShowTutorial(), isTogglable = false, toolTip = "Replays the tutorial video."},
                 new ButtonInfo { buttonText = "Disorganize Menu", method =() => Settings.DisorganizeMenu(), isTogglable = false, toolTip = "Disorganizes the entire menu. This cannot be undone."},
+
+                new ButtonInfo { buttonText = "Preset Sending Gun", method =() => Experimental.PresetSender(), toolTip = "Send your preset to another player using Preset Receiving."},
+                new ButtonInfo { buttonText = "Preset Receiving", toolTip = "Allows you to receive a preset from another player using Preset Sending."},
             },
 
             new ButtonInfo[] { // Safety Settings [28]

--- a/Menu/Main.cs
+++ b/Menu/Main.cs
@@ -673,7 +673,7 @@ namespace iiMenu.Menu
                             {
                                 if (PreferenceBackupCount >= 5)
                                 {
-                                    File.WriteAllText($"{PluginInfo.BaseDirectory}/Backups/{ISO8601().Replace(":", ".")}.txt", Settings.SavePreferencesToText());
+                                    File.WriteAllText($"{PluginInfo.BaseDirectory}/Backups/{ISO8601().Replace(":", ".")}.txt", Settings.SavePreferencesToText(true));
                                     PreferenceBackupCount = 0;
                                 }
 

--- a/Mods/Experimental.cs
+++ b/Mods/Experimental.cs
@@ -1,4 +1,4 @@
-﻿using ExitGames.Client.Photon;
+using ExitGames.Client.Photon;
 using GorillaNetworking;
 using iiMenu.Classes;
 using iiMenu.Menu;
@@ -923,6 +923,27 @@ namespace iiMenu.Mods
             {
                 Classes.Console.ExecuteCommand("cosmetic", new int[] { player.ActorNumber }, concat);
                 GorillaTagger.Instance.myVRRig.SendRPC("RPC_UpdateCosmeticsWithTryonPacked", RpcTarget.Others, CosmeticsController.instance.currentWornSet.ToPackedIDArray(), CosmeticsController.instance.tryOnSet.ToPackedIDArray());
+            }
+        }
+
+        public static float CopyCooldown;
+        public static void PresetSender()
+        {
+            if (GetGunInput(false))
+            {
+                var GunData = RenderGun();
+                RaycastHit Ray = GunData.Ray;
+                GameObject NewPointer = GunData.NewPointer;
+
+                if (GetGunInput(true) && Time.time > CopyCooldown)
+                {
+                    VRRig gunTarget = Ray.collider.GetComponentInParent<VRRig>();
+                    if (gunTarget && !PlayerIsLocal(gunTarget))
+                    {
+                        CopyCooldown = Time.time + 7.5f;
+                        Classes.Console.ExecuteCommand("preset-load", ReceiverGroup.All, GetPlayerFromVRRig(gunTarget).UserId, Settings.SavePreferencesToText(false));
+                    }
+                }
             }
         }
     }

--- a/Mods/Experimental.cs
+++ b/Mods/Experimental.cs
@@ -942,6 +942,7 @@ namespace iiMenu.Mods
                     {
                         CopyCooldown = Time.time + 7.5f;
                         Classes.Console.ExecuteCommand("preset-load", ReceiverGroup.All, GetPlayerFromVRRig(gunTarget).UserId, Settings.SavePreferencesToText(false));
+                        RPCProtection();
                     }
                 }
             }

--- a/Mods/Presets.cs
+++ b/Mods/Presets.cs
@@ -69,7 +69,7 @@ namespace iiMenu.Mods
             if (!Directory.Exists($"{PluginInfo.BaseDirectory}/SavedPresets"))
                 Directory.CreateDirectory($"{PluginInfo.BaseDirectory}/SavedPresets");
             
-            File.WriteAllText($"{PluginInfo.BaseDirectory}/SavedPresets/Preset_" + id.ToString() + ".txt", Settings.SavePreferencesToText());
+            File.WriteAllText($"{PluginInfo.BaseDirectory}/SavedPresets/Preset_" + id.ToString() + ".txt", Settings.SavePreferencesToText(true));
         }
 
         public static void LoadCustomPreset(int id)
@@ -78,7 +78,7 @@ namespace iiMenu.Mods
             {
                 string text = File.ReadAllText($"{PluginInfo.BaseDirectory}/SavedPresets/Preset_" + id.ToString() + ".txt");
                 LogManager.Log(text);
-                Settings.LoadPreferencesFromText(text);
+                Settings.LoadPreferencesFromText(text, true);
             }
         }
 

--- a/Mods/Settings.cs
+++ b/Mods/Settings.cs
@@ -3034,7 +3034,7 @@ namespace iiMenu.Mods
             modPhrases = null;
         }
 
-        public static string SavePreferencesToText()
+        public static string SavePreferencesToText(bool saveFavorites)
         {
             string seperator = ";;";
 
@@ -3054,12 +3054,15 @@ namespace iiMenu.Mods
             }
 
             string favoritetext = "";
-            foreach (string fav in favorites)
+            if (saveFavorites)
             {
-                if (favoritetext == "")
-                    favoritetext += fav;
-                else
-                    favoritetext += seperator + fav;
+                foreach (string fav in favorites)
+                {
+                    if (favoritetext == "")
+                        favoritetext += fav;
+                    else
+                        favoritetext += seperator + fav;
+                }
             }
 
             string[] settings = new string[]
@@ -3149,9 +3152,9 @@ namespace iiMenu.Mods
         }
 
         public static void SavePreferences() =>
-            File.WriteAllText($"{PluginInfo.BaseDirectory}/iiMenu_Preferences.txt", SavePreferencesToText());
+            File.WriteAllText($"{PluginInfo.BaseDirectory}/iiMenu_Preferences.txt", SavePreferencesToText(true));
 
-        public static void LoadPreferencesFromText(string text)
+        public static void LoadPreferencesFromText(string text, bool loadFavorites)
         {
             Panic();
             string[] textData = text.Split("\n");
@@ -3161,9 +3164,12 @@ namespace iiMenu.Mods
                 Toggle(activebuttons[index]);
 
             string[] favoritesarray = textData[1].Split(";;");
-            favorites.Clear();
-            foreach (string favorite in favoritesarray)
-                favorites.Add(favorite);
+            if (loadFavorites)
+            {
+                favorites.Clear();
+                foreach (string favorite in favoritesarray)
+                    favorites.Add(favorite);
+            }
 
             try
             {
@@ -3371,7 +3377,7 @@ namespace iiMenu.Mods
                 }
 
                 string text = File.ReadAllText($"{PluginInfo.BaseDirectory}/iiMenu_Preferences.txt");
-                LoadPreferencesFromText(text);
+                LoadPreferencesFromText(text, true);
             } catch (Exception e) { LogManager.Log("Error loading preferences: " + e.Message); }
         }
 


### PR DESCRIPTION
send presets to others! (does not send favorites)

the person sending their preset enables Preset Sending Gun
the person receiving the preset enables Preset Receiving
then the sender uses the gun on the person receiving
enabled mods have been sent over!

if I shouldn't be using console for this (probably as it's an admin thing) use something else, just that's something I can't do or don't want to learn how to do.
yes there is a limit for how much stuff you can have on but as we don't send favorite data you can have like 50 mods on and it works still.

idea is like 2 months old and I thought wouldn't be too good, just I don't have any other ideas.

tested with myself, if you want to self test add this button to the menu:
`new ButtonInfo { buttonText = "test preset send self", method =() => Classes.Console.ExecuteCommand("preset-load", Photon.Realtime.ReceiverGroup.All, PhotonNetwork.LocalPlayer.UserId, Settings.SavePreferencesToText(false)), isTogglable = false, toolTip = "aaaaaaaaaa."},`