### PR TITLE
user custom map scripts

### DIFF
--- a/Mods/CustomMaps/Manager.cs
+++ b/Mods/CustomMaps/Manager.cs
@@ -28,9 +28,7 @@ namespace iiMenu.Mods.CustomMaps
                 if (map == null)
                     buttons.Add(new ButtonInfo { buttonText = "This map is not supported yet.", label = true });
                 else
-                {
                     buttons.AddRange(map.Buttons);
-                }
 
                 buttons.Add(new ButtonInfo { buttonText = " ", label = true });
                 buttons.Add(new ButtonInfo { buttonText = "Edit custom script", method =() => editUserScript(), isTogglable = false, toolTip = "Opens your custom script for this map." });

--- a/Mods/CustomMaps/Manager.cs
+++ b/Mods/CustomMaps/Manager.cs
@@ -1,4 +1,4 @@
-﻿using GorillaTagScripts.ModIO;
+using GorillaTagScripts.ModIO;
 using iiMenu.Classes;
 using iiMenu.Menu;
 using iiMenu.Mods.CustomMaps.Maps;
@@ -28,7 +28,14 @@ namespace iiMenu.Mods.CustomMaps
                 if (map == null)
                     buttons.Add(new ButtonInfo { buttonText = "This map is not supported yet.", label = true });
                 else
+                {
                     buttons.AddRange(map.Buttons);
+                }
+
+                buttons.Add(new ButtonInfo { buttonText = " ", label = true });
+                buttons.Add(new ButtonInfo { buttonText = "Edit custom script", method =() => editUserScript(), isTogglable = false, toolTip = "Opens your custom script for this map." });
+                buttons.Add(new ButtonInfo { buttonText = "Delete custom script", method =() => deleteUserScript(), isTogglable = false, toolTip = "Deletes your custom script for this map." });
+                buttons.Add(new ButtonInfo { buttonText = "Run custom script", enableMethod =() => startUserScript(), disableMethod =() => stopUserScript(), toolTip = "Runs your custom script for this map." });
             }
             else
                 buttons.Add(new ButtonInfo { buttonText = "You have not loaded a map.", label = true });
@@ -57,6 +64,41 @@ namespace iiMenu.Mods.CustomMaps
             if (NetworkSystem.Instance.InRoom)
                 LuauHud.Instance.RestartLuauScript();
 
+            CustomMapManager.ReturnToVirtualStump();
+        }
+
+        public static void editUserScript()
+        {
+            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua";
+            if (!System.IO.File.Exists(DirectoryTarget))
+                System.IO.File.WriteAllText(DirectoryTarget, mapScriptArchives[CustomMapManager.currentRoomMapModId]);
+            System.Diagnostics.Process.Start(DirectoryTarget);
+        }
+
+        public static void deleteUserScript()
+        {
+            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua";
+            if (System.IO.File.Exists(DirectoryTarget))
+                System.IO.File.Delete(DirectoryTarget);
+        }
+
+        public static void startUserScript()
+        {
+            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua";
+            if (System.IO.File.Exists(DirectoryTarget))
+                CustomGameMode.LuaScript = System.IO.File.ReadAllText(DirectoryTarget);
+                
+            if (NetworkSystem.Instance.InRoom)
+                LuauHud.Instance.RestartLuauScript();
+            CustomMapManager.ReturnToVirtualStump();
+        }
+
+        public static void stopUserScript()
+        {
+            CustomGameMode.LuaScript = mapScriptArchives[CustomMapManager.currentRoomMapModId];
+
+            if (NetworkSystem.Instance.InRoom)
+                LuauHud.Instance.RestartLuauScript();
             CustomMapManager.ReturnToVirtualStump();
         }
 

--- a/Mods/CustomMaps/Manager.cs
+++ b/Mods/CustomMaps/Manager.cs
@@ -69,7 +69,7 @@ namespace iiMenu.Mods.CustomMaps
 
         public static void editUserScript()
         {
-            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua";
+            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.luau").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.luau";
             if (!System.IO.File.Exists(DirectoryTarget))
                 System.IO.File.WriteAllText(DirectoryTarget, mapScriptArchives[CustomMapManager.currentRoomMapModId]);
             System.Diagnostics.Process.Start(DirectoryTarget);
@@ -77,14 +77,14 @@ namespace iiMenu.Mods.CustomMaps
 
         public static void deleteUserScript()
         {
-            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua";
+            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.luau").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.luau";
             if (System.IO.File.Exists(DirectoryTarget))
                 System.IO.File.Delete(DirectoryTarget);
         }
 
         public static void startUserScript()
         {
-            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.lua";
+            string DirectoryTarget = System.IO.Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.luau").Split("BepInEx\\")[0] + $"{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.luau";
             if (System.IO.File.Exists(DirectoryTarget))
                 CustomGameMode.LuaScript = System.IO.File.ReadAllText(DirectoryTarget);
                 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Logging;
 using iiMenu.Menu;
 using iiMenu.Patches;
@@ -42,7 +42,8 @@ namespace iiMenu
                 "/Plugins",
                 "/Backups",
                 "/TTS",
-                "/PlayerInfo"
+                "/PlayerInfo",
+                "/CustomScripts"
             };
 
             foreach (string DirectoryString in ExistingDirectories)


### PR DESCRIPTION
lets the user modify the luau scripts for custom maps that don't have pre-made mods (and also ones that do!)

### Edit custom script
- creates the script at iisStupidMenu/CustomScripts/`Open map ID`.luau if it isn't already created
- opens the custom map script in the users default .luau opener (such as visual studio)
### Delete custom script
- deletes the script at iisStupidMenu/CustomScripts/`Open map ID`.luau if it exists
### Run custom script
- **on enable**: replaces the running script with whats in the file at iisStupidMenu/CustomScripts/`Open map ID`.luau if it exists
- **on disable**: replaces the running script with the old one

this can be used so users can easily make mods for custom maps they want mods for, and so people like you can see if the mod works before adding a button on the menu for it.

i wont be making any more stuff for this menu till next month, it doesn't work with built in scripts but the point is so the user can make their own, not use both at once.