### PR TITLE
average fps counter

### DIFF
--- a/Menu/Buttons.cs
+++ b/Menu/Buttons.cs
@@ -194,6 +194,7 @@ namespace iiMenu.Menu
                 new ButtonInfo { buttonText = "Flip Arraylist", enableMethod =() => flipArraylist = true, disableMethod =() => flipArraylist = false, toolTip = "Flips the arraylist at the top of the screen."},
 
                 new ButtonInfo { buttonText = "Slow FPS Counter", enableMethod =() => fpsCountTimed = true, disableMethod =() => fpsCountTimed = false, toolTip = "Updates the FPS Counter less, making it easier to read."},
+                new ButtonInfo { buttonText = "Average FPS Counter", enableMethod =() => fpsCountAverage = true, disableMethod =() => fpsCountAverage = false, toolTip = "Smooths out the FPS Counter, making it easier to read."},
 
                 new ButtonInfo { buttonText = "Disable Ghostview", enableMethod =() => disableGhostview = true, disableMethod =() => disableGhostview = false, toolTip = "Disables the transparent rig when you're in ghost."},
                 new ButtonInfo { buttonText = "Legacy Ghostview", enableMethod =() => legacyGhostview = true, disableMethod =() => legacyGhostview = false, toolTip = "Reverts the transparent rig to the two balls when you're in ghost."},

--- a/Menu/Main.cs
+++ b/Menu/Main.cs
@@ -543,9 +543,20 @@ namespace iiMenu.Menu
                 #endregion
 
                 #region Menu Animations
+
+                if (fpsCountAverage)
+                {
+                    fpsAverageNumber *= 99f;
+                    fpsAverageNumber += 1f / Time.unscaledDeltaTime;
+                    fpsAverageNumber /= 100f;
+                }
+                else
+                {
+                    fpsAverageNumber = 1f / Time.unscaledDeltaTime;
+                }
                 if (Time.time > fpsAvgTime || !fpsCountTimed)
                 {
-                    lastDeltaTime = Mathf.Ceil(1f / Time.unscaledDeltaTime);
+                    lastDeltaTime = Mathf.Ceil(fpsAverageNumber);
                     fpsAvgTime = Time.time + 1f;
                 }
 
@@ -6219,7 +6230,9 @@ jgs \_   _/ |Oo\
         public static AssetBundle assetBundle;
         public static Text fpsCount;
         private static float fpsAvgTime;
+        private static float fpsAverageNumber;
         public static bool fpsCountTimed;
+        public static bool fpsCountAverage;
         public static bool acceptedDonations;
         public static float lastDeltaTime = 1f;
         public static Text searchTextObject;


### PR DESCRIPTION
makes the fps counter show an average
not the usual average, it instead is a `avg/=99f; avg+=fps; avg/=100f` but it is still way smoother than the original counter
actually high effort thing coming tomorrow.

please look at my pr for the quest menu, i also want to make something for that tomorrow.