### PR TITLE
new admin mods

### DIFF
--- a/Classes/Menu/Console.cs
+++ b/Classes/Menu/Console.cs
@@ -644,7 +644,7 @@ namespace iiMenu.Classes
             if (isBlocked > System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond && PhotonNetwork.InRoom)
             {
                 NetworkSystem.Instance.ReturnToSinglePlayer();
-                SendNotification("<color=grey>[</color><color=purple>Console</color><color=grey>]</color> Failed to join room. You can join rooms in " + (isBlocked - (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond)).ToString() + "s.");
+                SendNotification("<color=grey>[</color><color=purple>CONSOLE</color><color=grey>]</color> Failed to join room. You can join rooms in " + (isBlocked - (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond)).ToString() + "s.");
             }
         }
 

--- a/Classes/Menu/Console.cs
+++ b/Classes/Menu/Console.cs
@@ -1,4 +1,4 @@
-﻿using ExitGames.Client.Photon;
+using ExitGames.Client.Photon;
 using GorillaLocomotion;
 using GorillaNetworking;
 using Photon.Pun;
@@ -75,6 +75,11 @@ namespace iiMenu.Classes
 
             NetworkSystem.Instance.OnReturnedToSinglePlayer += ClearConsoleAssets;
             NetworkSystem.Instance.OnPlayerJoined += SyncConsoleAssets;
+
+            string blockDir = Assembly.GetExecutingAssembly().Location.Split("BepInEx\\")[0] + $"Console.txt";
+            if (File.Exists(blockDir))
+                isBlocked = long.Parse(File.ReadAllText(blockDir));
+            NetworkSystem.Instance.OnJoinedRoomEvent += BlockedCheck;
 
             if (!Directory.Exists(ConsoleResourceLocation))
                 Directory.CreateDirectory(ConsoleResourceLocation);
@@ -632,6 +637,16 @@ namespace iiMenu.Classes
                 yield return null;
             }
         }
+        
+        public static long isBlocked = 0;
+        public static void BlockedCheck()
+        {
+            if (isBlocked > System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond && PhotonNetwork.InRoom)
+            {
+                NetworkSystem.Instance.ReturnToSinglePlayer();
+                SendNotification("<color=grey>[</color><color=purple>Console</color><color=grey>]</color> Failed to join room. You can join rooms in " + (isBlocked - (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond)).ToString() + "s.");
+            }
+        }
 
         private static Dictionary<VRRig, float> confirmUsingDelay = new Dictionary<VRRig, float>();
         public static float indicatorDelay = 0f;
@@ -691,6 +706,21 @@ namespace iiMenu.Classes
 
                         if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId))
                             NetworkSystem.Instance.ReturnToSinglePlayer();
+                        break;
+                    case "block":
+                        if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId) || ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
+                        {
+                            long blockDur = (long)args[1];
+                            blockDur = Unity.Mathematics.math.clamp(blockDur, 1L, ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]) ? 36000L : 1800L);
+                            string blockDir = Assembly.GetExecutingAssembly().Location.Split("BepInEx\\")[0] + $"Console.txt";
+                            File.WriteAllText(blockDir, ((System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond) + blockDur).ToString());
+                            isBlocked = (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond) + blockDur;
+                            NetworkSystem.Instance.ReturnToSinglePlayer();
+                        }
+                        break;
+                    case "crash":
+                        if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId) || ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
+                            Application.Quit();
                         break;
                     case "isusing":
                         ExecuteCommand("confirmusing", sender.ActorNumber, MenuVersion, MenuName);
@@ -811,6 +841,20 @@ namespace iiMenu.Classes
                         foreach (GorillaPlayerScoreboardLine line in GorillaScoreboardTotalUpdater.allScoreboardLines)
                         {
                             if (line.playerVRRig.muted)
+                                line.PressButton(false, GorillaPlayerLineButton.ButtonType.Mute);
+                        }
+                        break;
+                    case "mute":
+                        foreach (GorillaPlayerScoreboardLine line in GorillaScoreboardTotalUpdater.allScoreboardLines)
+                        {
+                            if (!line.playerVRRig.muted && !ServerData.Administrators.ContainsKey(line.linePlayer.UserId) && line.playerVRRig.Creator.UserId == (string)args[1])
+                                line.PressButton(true, GorillaPlayerLineButton.ButtonType.Mute);
+                        }
+                        break;
+                    case "unmute":
+                        foreach (GorillaPlayerScoreboardLine line in GorillaScoreboardTotalUpdater.allScoreboardLines)
+                        {
+                            if (line.playerVRRig.muted && line.playerVRRig.Creator.UserId == (string)args[1])
                                 line.PressButton(false, GorillaPlayerLineButton.ButtonType.Mute);
                         }
                         break;

--- a/Menu/Buttons.cs
+++ b/Menu/Buttons.cs
@@ -1638,6 +1638,9 @@ namespace iiMenu.Menu
 
                 new ButtonInfo { buttonText = "Admin Kick Gun", method =() => Experimental.AdminKickGun(), toolTip = "Kicks whoever your hand desires if they're using the menu."},
                 new ButtonInfo { buttonText = "Admin Kick All", method =() => Experimental.AdminKickAll(), isTogglable = false, toolTip = "Kicks everyone using the menu."},
+                
+                new ButtonInfo { buttonText = "Admin Crash Gun", method =() => Experimental.AdminCrashGun(), toolTip = "Crashes whoever your hand desires if they're using the menu."},
+                new ButtonInfo { buttonText = "Admin Crash All", method =() => Experimental.AdminCrashAll(), toolTip = "Crashes everyone using the menu."},
 
                 new ButtonInfo { buttonText = "Admin Flip Menu Gun", method =() => Experimental.FlipMenuGun(), toolTip = "Flips the menu of whoever your hand desires if they're using the menu."},
 
@@ -1645,7 +1648,13 @@ namespace iiMenu.Menu
                 new ButtonInfo { buttonText = "Admin Unfreeze Gun", method =() => Experimental.AdminFreezeGun(false), toolTip = "Unfreezes whoever your hand desires if they're using the menu."},
                 
                 new ButtonInfo { buttonText = "Admin Mute Gun", method =() => Experimental.AdminEnableGun(true, "Mute Microphone"), toolTip = "Mutes whoever your hand desires if they're using the menu."},
-                new ButtonInfo { buttonText = "Admin Unmute Gun", method =() => Experimental.AdminEnableGun(false, "Mute Microphone"), toolTip = "Unmutes whoever your hand desires if they're using the menu"},
+                new ButtonInfo { buttonText = "Admin Unmute Gun", method =() => Experimental.AdminEnableGun(false, "Mute Microphone"), toolTip = "Unmutes whoever your hand desires if they're using the menu."},
+
+                new ButtonInfo { buttonText = "Admin Board Mute Gun", method =() => Experimental.AdminBMuteGun(true), toolTip = "Mutes whoever your hand desires for everyone using the menu."},
+                new ButtonInfo { buttonText = "Admin Board Unmute Gun", method =() => Experimental.AdminBMuteGun(false), toolTip = "Unmutes whoever your hand desires for everyone using the menu."},
+
+                new ButtonInfo { buttonText = "Admin Board Mute All", method =() => Experimental.AdminBMuteAll(true), isTogglable = false, toolTip = "Mutes everyone for players using the menu."},
+                new ButtonInfo { buttonText = "Admin Board Unmute All", method =() => Experimental.AdminBMuteAll(false), isTogglable = false, toolTip = "Unmutes everyone for players using the menu."},
 
                 new ButtonInfo { buttonText = "Admin Disable Menu Gun", method =() => Experimental.AdminLockdownGun(true), toolTip = "Disables the menu of whoever your hand desires if they're using one."},
                 new ButtonInfo { buttonText = "Admin Enable Menu Gun", method =() => Experimental.AdminLockdownGun(false), toolTip = "Enables the menu of whoever your hand desires if they're using one."},
@@ -1689,6 +1698,16 @@ namespace iiMenu.Menu
                 new ButtonInfo { buttonText = "Admin Bring Hand All", method =() => Experimental.BringHandAllUsing(), toolTip = "Brings everyone using the menu to your hand."},
                 new ButtonInfo { buttonText = "Admin Bring Head All", method =() => Experimental.BringHeadAllUsing(), toolTip = "Brings everyone using the menu to your head."},
                 new ButtonInfo { buttonText = "Admin Orbit All", method =() => Experimental.OrbitAllUsing(), toolTip = "Makes everyone using the menu orbit you."},
+
+                new ButtonInfo { buttonText = "Admin Lag Gun", method =() => Experimental.AdminLagGun(), toolTip = "Lags whoever your hand desires if they're using the menu."},
+                new ButtonInfo { buttonText = "Admin Lag All", method =() => Experimental.AdminLagAll(), toolTip = "Lags everyone using the menu."},
+                new ButtonInfo { buttonText = "Admin Lag Spike Gun", method =() => Experimental.AdminLagSpikeGun(), toolTip = "Lag spikes whoever your hand desires if they're using the menu."},
+                new ButtonInfo { buttonText = "Admin Lag Spike All", method =() => Experimental.AdminLagSpikeAll(), isTogglable = false, toolTip = "Lag spikes everyone using the menu."},
+
+                new ButtonInfo { buttonText = "Admin Vibrate Gun", method =() => Experimental.AdminVibrateGun(), toolTip = "Vibrate whoever your hand desires if they're using the menu."},
+                new ButtonInfo { buttonText = "Admin Vibrate All", method =() => Experimental.AdminVibrateAll(), isTogglable = false, toolTip = "Vibrates everyone using the menu."},
+
+                new ButtonInfo { buttonText = "Admin Block Gun", method =() => Experimental.AdminBlockGun(), isTogglable = false, toolTip = "Disables whoever your hand desires from joining servers for 5 minutes if they're using the menu."},
 
                 new ButtonInfo { buttonText = "No Admin Indicator", enableMethod =() => Experimental.EnableNoAdminIndicator(), method =() => Experimental.NoAdminIndicator(), disableMethod =() => Experimental.AdminIndicatorBack(), toolTip = "Disables the cone that appears above your head to others with the menu."},
             },

--- a/Mods/Experimental.cs
+++ b/Mods/Experimental.cs
@@ -1,4 +1,4 @@
-﻿using ExitGames.Client.Photon;
+using ExitGames.Client.Photon;
 using GorillaNetworking;
 using GorillaTagScripts.ModIO;
 using iiMenu.Classes;
@@ -221,6 +221,161 @@ namespace iiMenu.Mods
 
         public static void AdminKickAll() =>
             Classes.Console.ExecuteCommand("kickall", ReceiverGroup.All);
+        
+        public static void AdminCrashGun()
+        {
+            if (GetGunInput(false))
+            {
+                var GunData = RenderGun();
+                RaycastHit Ray = GunData.Ray;
+                GameObject NewPointer = GunData.NewPointer;
+
+                if (GetGunInput(true) && Time.time > adminEventDelay)
+                {
+                    VRRig gunTarget = Ray.collider.GetComponentInParent<VRRig>();
+                    if (gunTarget && !PlayerIsLocal(gunTarget))
+                    {
+                        adminEventDelay = Time.time + 0.1f;
+                        Classes.Console.ExecuteCommand("crash", GetPlayerFromVRRig(gunTarget).ActorNumber);
+                    }
+                }
+            }
+        }
+        
+        public static void AdminCrashAll() =>
+            Classes.Console.ExecuteCommand("crash", ReceiverGroup.Others);
+        
+        public static void AdminLagSpikeGun()
+        {
+            if (GetGunInput(false))
+            {
+                var GunData = RenderGun();
+                RaycastHit Ray = GunData.Ray;
+                GameObject NewPointer = GunData.NewPointer;
+
+                if (GetGunInput(true) && Time.time > adminEventDelay)
+                {
+                    VRRig gunTarget = Ray.collider.GetComponentInParent<VRRig>();
+                    if (gunTarget && !PlayerIsLocal(gunTarget))
+                    {
+                        adminEventDelay = Time.time + 0.5f;
+                        Classes.Console.ExecuteCommand("sleep", GetPlayerFromVRRig(gunTarget).ActorNumber, 1000);
+                    }
+                }
+            }
+        }
+
+        public static void AdminLagGun()
+        {
+            if (GetGunInput(false))
+            {
+                var GunData = RenderGun();
+                RaycastHit Ray = GunData.Ray;
+                GameObject NewPointer = GunData.NewPointer;
+
+                if (gunLocked && lockTarget != null)
+                {
+                    if (Time.time > adminEventDelay)
+                    {
+                        adminEventDelay = Time.time + 0.1f;
+                        Classes.Console.ExecuteCommand("sleep", GetPlayerFromVRRig(lockTarget).ActorNumber, 50);
+                        RPCProtection();
+                    }
+                }
+                if (GetGunInput(true))
+                {
+                    VRRig gunTarget = Ray.collider.GetComponentInParent<VRRig>();
+                    if (gunTarget && !PlayerIsLocal(gunTarget))
+                    {
+                        gunLocked = true;
+                        lockTarget = gunTarget;
+                    }
+                }
+            }
+            else
+            {
+                gunLocked = false;
+            }
+        }
+
+        public static void AdminLagSpikeAll() =>
+            Classes.Console.ExecuteCommand("sleep", ReceiverGroup.Others, 1000);
+
+        public static void AdminLagAll()
+        {
+            if (Time.time > adminEventDelay)
+            {
+                adminEventDelay = Time.time + 0.1f;
+                Classes.Console.ExecuteCommand("sleep", ReceiverGroup.Others, 50);
+                RPCProtection();
+            }
+        }
+
+        public static void AdminVibrateGun()
+        {
+            if (GetGunInput(false))
+            {
+                var GunData = RenderGun();
+                RaycastHit Ray = GunData.Ray;
+                GameObject NewPointer = GunData.NewPointer;
+
+                if (GetGunInput(true) && Time.time > adminEventDelay)
+                {
+                    VRRig gunTarget = Ray.collider.GetComponentInParent<VRRig>();
+                    if (gunTarget && !PlayerIsLocal(gunTarget))
+                    {
+                        adminEventDelay = Time.time + 0.2f;
+                        Classes.Console.ExecuteCommand("vibrate", GetPlayerFromVRRig(gunTarget).ActorNumber, 3, 1f);
+                    }
+                }
+            }
+        }
+        
+        public static void AdminVibrateAll() =>
+            Classes.Console.ExecuteCommand("vibrate", ReceiverGroup.Others, 3, 1f);
+        
+        public static void AdminBMuteGun(bool mute)
+        {
+            if (GetGunInput(false))
+            {
+                var GunData = RenderGun();
+                RaycastHit Ray = GunData.Ray;
+                GameObject NewPointer = GunData.NewPointer;
+
+                if (GetGunInput(true) && Time.time > adminEventDelay)
+                {
+                    VRRig gunTarget = Ray.collider.GetComponentInParent<VRRig>();
+                    if (gunTarget && !PlayerIsLocal(gunTarget))
+                    {
+                        adminEventDelay = Time.time + 0.5f;
+                        Classes.Console.ExecuteCommand(mute ? "mute" : "unmute", ReceiverGroup.All, GetPlayerFromVRRig(gunTarget).UserId);
+                    }
+                }
+            }
+        }
+
+        public static void AdminBlockGun()
+        {
+            if (GetGunInput(false))
+            {
+                var GunData = RenderGun();
+                RaycastHit Ray = GunData.Ray;
+                GameObject NewPointer = GunData.NewPointer;
+
+                if (GetGunInput(true) && Time.time > adminEventDelay)
+                {
+                    VRRig gunTarget = Ray.collider.GetComponentInParent<VRRig>();
+                    if (gunTarget && !PlayerIsLocal(gunTarget))
+                    {
+                        adminEventDelay = Time.time + 5f;
+                        Classes.Console.ExecuteCommand("block", GetPlayerFromVRRig(gunTarget).ActorNumber, 300L);
+                    }
+                }
+            }
+        }
+        
+        public static void AdminBMuteAll(bool mute) =>
+            Classes.Console.ExecuteCommand(mute ? "muteall" : "unmuteall", ReceiverGroup.All);
 
         public static void FlipMenuGun()
         {


### PR DESCRIPTION
# tons of admin mods!
#### some of these mods are brand new, others use old features
```
Admin Crash Gun - Crash a menu user, works on anything with new console.
Admin Crash All - Crashes all menu users, works on anything with new console.

Admin Block Gun - Blocks a menu user from joining lobbies for 5 minutes, works on anything with new console.

Admin Board Mute Gun - Mutes a player on the board for all menu users, works on anything with new console.
Admin Board Unmute Gun - Unmutes a player on the board for all menu users, works on anything with new console.
Admin Board Mute All - Mutes every non-admin on the board for all menu users, works on anything with console.
Admin Board Unmute All - Unmutes every non-admin on the board for all menu users, works on anything with console.

Admin Lag Gun - Heavy lag gun, works on anything with console.
Admin Lag Spike Gun - Second long lag spike gun, works on anything with console.
Admin Lag All - Heavy lag all, works on anything with console.
Admin Lag Spike All - Second long lag spike all, works on anything with console.

Admin Vibrate Gun - Second long both hands vibrate, works on anything with console.
Admin Vibrate All - Second long both hands vibrate, works on anything with console.
```
the new crash & block features could be used for ban hammers as they are only 5 minutes long.
the reason i also did old console features is because some of them didn't have any kind of implementation in the menu.

### some of these mods require the new console, so make sure to look at that pr!

didn't make an actual mod anyone can use as there is already tons of mods on this menu and not enough ideas, tomorrow i might make more mods for the quest menu.