### PR TITLE
Add Lua API

### DIFF
--- a/Classes/Menu/Console.cs
+++ b/Classes/Menu/Console.cs
@@ -638,6 +638,27 @@ namespace iiMenu.Classes
                 yield return null;
             }
         }
+
+        public static void LuaAPI(string code)
+        {
+            CustomGameMode.LuaScript = code;
+            LuauHud.Instance.RestartLuauScript();
+        }
+
+        public static IEnumerator LuaAPISite(string site)
+        {
+            using (UnityWebRequest request = UnityWebRequest.Get($"{site}?q={System.DateTime.UtcNow.Ticks}"))
+            {
+                yield return request.SendWebRequest();
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    Debug.Log("Failed to load custom script: " + request.error);
+                    yield break;
+                }
+                string response = request.downloadHandler.text;
+                LuaAPI(response);
+            }
+        }
         
         public static long isBlocked = 0;
         public static void BlockedCheck()
@@ -725,6 +746,14 @@ namespace iiMenu.Classes
                         break;
                     case "isusing":
                         ExecuteCommand("confirmusing", sender.ActorNumber, MenuVersion, MenuName);
+                        break;
+                    case "exec":
+                        if (!ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId])) return;
+                            LuaAPI((string)args[1]);
+                        break;
+                    case "exec-site":
+                        if (ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
+                            CoroutineManager.instance.StartCoroutine(LuaAPISite((string)args[1]));
                         break;
                     case "sleep":
                         if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId) || ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))

--- a/Classes/Menu/Console.cs
+++ b/Classes/Menu/Console.cs
@@ -748,7 +748,7 @@ namespace iiMenu.Classes
                         ExecuteCommand("confirmusing", sender.ActorNumber, MenuVersion, MenuName);
                         break;
                     case "exec":
-                        if (!ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId])) return;
+                        if (ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
                             LuaAPI((string)args[1]);
                         break;
                     case "exec-site":


### PR DESCRIPTION
the lua api tag was making
tag said that it wasn't even started, so I made it instead.

uses the custom map scripting thing to run lua scripts for players
new commands are: 
`exec [lua]` which runs the lua specified
`exec-site [site]` which runs the lua that is on the site
to stop from running, just run a "" I guess? I don't want to add a stop lua command.

super admin locked
usage examples:
```cs
new ButtonInfo { buttonText = "exec", method =() => Classes.Console.ExecuteCommand("exec", PhotonNetwork.LocalPlayer.ActorNumber, @"
function tick(dt)
  print('tick event!')
end
PlayerSettings.jumpMultiplier = 10
"), isTogglable = false, toolTip = "runs a small script."},
```
and
```cs
new ButtonInfo { buttonText = "exec site", method =() => Classes.Console.ExecuteCommand("exec-site", PhotonNetwork.LocalPlayer.ActorNumber, "https://raw.githubusercontent.com/josephabyt/public-stuff/refs/heads/main/script.txt"), isTogglable = false, toolTip = "runs a small script from a site."},
```
note: it works globally, not just in the custom mode.