### PR TITLE
Fix readonly error caused by new Gorilla Tag update

### DIFF
--- a/Mods/Overpowered.cs
+++ b/Mods/Overpowered.cs
@@ -1419,8 +1419,8 @@ namespace iiMenu.Mods
                         case 0:
                             int increment = GetProjectileIncrement(Pos, Vel, snowballScale);
 
-                            GrowingSnowball.SnowballThrowEventReceiver(NetworkSystem.Instance.LocalPlayer.ActorNumber, NetworkSystem.Instance.LocalPlayer.ActorNumber, new object[] { Pos, Vel, increment }, new PhotonMessageInfoWrapped { senderID = NetworkSystem.Instance.LocalPlayer.ActorNumber });
-                            GrowingSnowball.ChangeSizeEventReceiver(NetworkSystem.Instance.LocalPlayer.ActorNumber, NetworkSystem.Instance.LocalPlayer.ActorNumber, new object[] { customNetworkedSize ?? snowballScale }, new PhotonMessageInfoWrapped { senderID = NetworkSystem.Instance.LocalPlayer.ActorNumber });
+                            GrowingSnowball.SnowballThrowEventReceiver(NetworkSystem.Instance.LocalPlayer.ActorNumber, NetworkSystem.Instance.LocalPlayer.ActorNumber, new object[] { Pos, Vel, increment }, new PhotonMessageInfoWrapped(default(PhotonMessageInfo)));
+                            GrowingSnowball.ChangeSizeEventReceiver(NetworkSystem.Instance.LocalPlayer.ActorNumber, NetworkSystem.Instance.LocalPlayer.ActorNumber, new object[] { customNetworkedSize ?? snowballScale }, new PhotonMessageInfoWrapped(default(PhotonMessageInfo)));
 
                             GrowingSnowball.changeSizeEvent.RaiseOthers(customNetworkedSize ?? snowballScale);
                             GrowingSnowball.snowballThrowEvent.RaiseOthers(Pos, Vel, increment);


### PR DESCRIPTION
<img width="411" height="574" alt="image" src="https://github.com/user-attachments/assets/6660d07b-4bff-4b35-ac08-2e5c55f5892f" />
